### PR TITLE
Modify dependency installation step in release workflow

### DIFF
--- a/.github/workflows/release-apk.yaml
+++ b/.github/workflows/release-apk.yaml
@@ -45,7 +45,9 @@ jobs:
           EOF
 
       - name: Get dependencies
-        run: flutter pub get
+        run: |
+          flutter pub get
+          sed -i -e 's/-Wl,/-Wl,--build-id=none,/' ${PUB_CACHE}/hosted/*/jni-*/src/CMakeLists.txt
       
       - name: Run tests
         run: flutter test


### PR DESCRIPTION
Add build ID option to CMakeLists.txt during dependency installation.
For #19 